### PR TITLE
Fix the `weights` error arising from `||`

### DIFF
--- a/R/ccdrAlgorithm-main.R
+++ b/R/ccdrAlgorithm-main.R
@@ -471,7 +471,7 @@ ccdr_singleR <- function(cors,
     ### Check weights
     if(length(weights) != pp*pp) stop(sprintf("weights must have length p^2 = %d!", pp*pp))
     if(!is.numeric(weights)) stop("weights must be numeric!")
-    if(weights < -1 || weights > 1) stop("weights out of bounds!")
+    if(any(weights < -1 | weights > 1)) stop("weights out of bounds!")
 
     ### Check gamma
     if(!is.numeric(gamma)) stop("gamma must be numeric!")


### PR DESCRIPTION
Hello. Thank you for developing this important and fast library for BN inference.
On the latest version of R, the `ccdr.run` function results in the corresponding error because of `||`.

```r
### Generate some random data
dat <- matrix(rnorm(1000), nrow = 20)
dat <- sparsebnUtils::sparsebnData(dat, type = "continuous")
# Run with default settings
ccdr.run(data = dat, lambdas.length = 20)
```
```
Error in weights < -1 || weights > 1 : 
  'length = 2500' in coercion to 'logical(1)'
```

This PR removes the error, and possibly solves https://github.com/itsrainingdata/sparsebn/issues/14.

I would be grateful if you could review the codes for the possible merging.
